### PR TITLE
Fix to support Sketch v45

### DIFF
--- a/butter.sketchplugin/Contents/Sketch/butter.js
+++ b/butter.sketchplugin/Contents/Sketch/butter.js
@@ -126,7 +126,7 @@ var sortSelectedLayersInList = function(sortedLayers){
     notify("Please select multiple layers in one group");
     return;
   }
-
+/*
   // save layer indices
   var parent = selection[0].parentGroup();
   var layerIndices = [];
@@ -150,6 +150,8 @@ var sortSelectedLayersInList = function(sortedLayers){
     [parent insertLayers:layerArray atIndex:index];
     [sortedLayer select:true byExpandingSelection:true];
   }
+  */
+  
 }
 
 // loops over selection to check if they're multiple, and part of the same group


### PR DESCRIPTION
Layer insertion functions no longer supported in Sketch v45 - specifically insertLayers_atIndex line 150.

Couldn't find out how the API has changed for this function, and I couldn't figure out why the plugin was re-ordering the layers in the layer list in any case (never noticed it in the past), so I've just commented out the block of code that's doing it. 

Objects are moved/aligned as expected, tested in all directions with and without margins.